### PR TITLE
Remove IntWars and Sightstone from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "intwars-client",
+  "name": "leaguesandbox-lobbyclient",
   "version": "0.0.1",
-  "description": "Client for the Sightstone IntWars sandbox.",
+  "description": "Lobby client for the League Sandbox project.",
   "main": "src/browser/main.js",
   "scripts": {
     "start": "./node_modules/.bin/electron .",


### PR DESCRIPTION
Remove mentions of IntWars and Sightstone from package.json, as they're now unrelated
