### PR TITLE
Fade out modals, close various screens on ESC.

### DIFF
--- a/src/ui/components/selectChampion/selectChampionCtrl.ts
+++ b/src/ui/components/selectChampion/selectChampionCtrl.ts
@@ -23,7 +23,9 @@ interface SelectChampionScope extends ng.IScope {
     isSelected: (champ: dd.Champion) => boolean;
     getSelectedPortrait: () => string;
     select: (champ: dd.Champion) => void;
-    finish: () => void;
+    
+    finish: (champ?: dd.Champion) => void;
+    closeEsc: (event: KeyboardEvent) => void;
 }
 
 export default class SelectChampionController {
@@ -43,8 +45,15 @@ export default class SelectChampionController {
             return $scope.currentChampion === c;
         };
         
-        $scope.finish = () => {
-            modal.finish($scope.currentChampion);  
+        const listener = (evnt: KeyboardEvent) => {
+            if (evnt.keyCode !== 27) return;
+            $scope.$apply(() => $scope.finish(modal.activeModal.params[1]));
+        };
+        document.addEventListener("keyup", listener);
+        
+        $scope.finish = (tgt = $scope.currentChampion) => {
+            document.removeEventListener("keyup", listener);
+            modal.finish(tgt);  
         };
         
         $scope.getPortraitPath = c => {

--- a/src/ui/components/selectSummonerSpell/selectSummonerSpellCtrl.ts
+++ b/src/ui/components/selectSummonerSpell/selectSummonerSpellCtrl.ts
@@ -18,7 +18,7 @@ interface SelectSummonerSpellScope extends ng.IScope {
     options: SummonerSpell[];
     selected: SummonerSpell;
     
-    finish: () => void;
+    finish: (spell?: SummonerSpell) => void;
     select: (SummonerSpell) => void;
 }
 
@@ -42,7 +42,15 @@ export default class SelectSummonerSpellController {
         ]
         
         $scope.selected = modal.activeModal.params[0];
-        $scope.finish = () => {
+        
+        const listener = (evnt: KeyboardEvent) => {
+            if (evnt.keyCode !== 27) return;
+            $scope.$apply(() => $scope.finish(modal.activeModal.params[0]));
+        };
+        document.addEventListener("keyup", listener);
+        
+        $scope.finish = (spell = $scope.selected) => {
+            document.removeEventListener("keyup", listener);
             modal.finish($scope.selected);
         };
         

--- a/src/ui/css/animations.less
+++ b/src/ui/css/animations.less
@@ -38,6 +38,15 @@
 	});
 }
 
+.fade-out-remove {
+	.animation(fadeOutRemove; {
+		opacity: 1;
+	}; {
+		opacity: 0;
+		visibility: hidden;
+	});	
+}
+
 // Wobble animation. Credits go to animate.css, https://github.com/daneden/animate.css
 @keyframes wobble {
 	from {

--- a/src/ui/services/modal/modalDirective.ts
+++ b/src/ui/services/modal/modalDirective.ts
@@ -26,7 +26,7 @@ export class ModalCtrl {
 }
 
 const TEMPLATE = `
-<div class="modal-container fade-in" ng-if="modal.active" style="display: block !important;">
+<div class="modal-container fade-in" ng-class="{ 'fade-out-remove': !modal.active }">
     <div class="modal-backdrop"></div>
     <div class="modal-content" compile="modal.active.content"></div>
 </div>


### PR DESCRIPTION
Fixes #8, #11. Currently the ESC closes the modal with the _old_ value, not the selected one. I felt this was better because one presses ESC to close/undo, not to confirm.
